### PR TITLE
Remote Windows overlay transparency fix

### DIFF
--- a/Controller/Classes/OverlayWindowMonoGame.cs
+++ b/Controller/Classes/OverlayWindowMonoGame.cs
@@ -1,0 +1,108 @@
+﻿#if WINDOWS
+using System.Windows.Forms;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace Blizzard_Controller;
+public class OverlayWindowMonoGame : Game
+{
+    private GraphicsDeviceManager _graphics;
+    private SpriteBatch _spriteBatch;
+
+    public OverlayWindowMonoGame()
+    {
+        _graphics = new GraphicsDeviceManager(this);
+        IsMouseVisible = false; // no cursor
+    }
+
+    protected override void LoadContent()
+    {
+        _spriteBatch = new SpriteBatch(GraphicsDevice);
+
+        var hwnd = Window.Handle;
+
+        // make window layered + click-through
+        SetWindowExStyle(hwnd, WS_EX_LAYERED | WS_EX_TRANSPARENT);
+
+        MakeBorderless(hwnd);
+
+        // set magenta as transparent color key
+        SetLayeredWindowAttributes(hwnd, COLOR_KEY, 0, LWA_COLORKEY);
+
+        var form = (Form)Control.FromHandle(Window.Handle);
+        form.TopMost = true; // <-- keeps window always on top
+    }
+
+    private void MakeBorderless(IntPtr hwnd)
+    {
+        if (IntPtr.Size == 8)
+        {
+            var style = GetWindowLongPtr64(hwnd, GWL_STYLE).ToInt64();
+            // clear existing style and set WS_POPUP
+            SetWindowLongPtr64(hwnd, GWL_STYLE, new IntPtr(WS_POPUP));
+        }
+        else
+        {
+            var style = GetWindowLong32(hwnd, GWL_STYLE);
+            SetWindowLong32(hwnd, GWL_STYLE, unchecked((int)WS_POPUP));
+        }
+    }
+
+
+    protected override void Update(GameTime gameTime)
+    {
+        base.Update(gameTime);
+    }
+
+    protected override void Draw(GameTime gameTime)
+    {
+        // clear with the colorkey color (magenta)
+        GraphicsDevice.Clear(new Microsoft.Xna.Framework.Color(255, 0, 255));
+
+        _spriteBatch.Begin();
+        //_spriteBatch.Draw(GetDummyTexture(Color.White), new Microsoft.Xna.Framework.Rectangle(100, 100, 200, 200), Microsoft.Xna.Framework.Color.White * 0.7f);
+        _spriteBatch.End();
+
+        base.Draw(gameTime);
+    }
+
+    #region Win32 Interop
+
+    const int GWL_EXSTYLE = -20;
+    const uint WS_EX_LAYERED = 0x00080000;
+    const uint WS_EX_TRANSPARENT = 0x00000020;
+    const uint LWA_COLORKEY = 0x00000001;
+    const uint COLOR_KEY = 0x00FF00FF; // magenta in 0x00BBGGRR
+    const int GWL_STYLE = -16;
+    const uint WS_POPUP = 0x80000000;
+
+
+    [DllImport("user32.dll", EntryPoint = "GetWindowLong")]
+    static extern int GetWindowLong32(IntPtr hWnd, int nIndex);
+    [DllImport("user32.dll", EntryPoint = "SetWindowLong")]
+    static extern int SetWindowLong32(IntPtr hWnd, int nIndex, int dwNewLong);
+    [DllImport("user32.dll", EntryPoint = "GetWindowLongPtr")]
+    static extern IntPtr GetWindowLongPtr64(IntPtr hWnd, int nIndex);
+    [DllImport("user32.dll", EntryPoint = "SetWindowLongPtr")]
+    static extern IntPtr SetWindowLongPtr64(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+    [DllImport("user32.dll")]
+    static extern bool SetLayeredWindowAttributes(IntPtr hwnd, uint crKey, byte bAlpha, uint dwFlags);
+
+    private IntPtr SetWindowExStyle(IntPtr hwnd, uint addFlags)
+    {
+        if (IntPtr.Size == 8)
+        {
+            var cur = GetWindowLongPtr64(hwnd, GWL_EXSTYLE);
+            var newv = new IntPtr(cur.ToInt64() | addFlags);
+            return SetWindowLongPtr64(hwnd, GWL_EXSTYLE, newv);
+        }
+        else
+        {
+            int cur = GetWindowLong32(hwnd, GWL_EXSTYLE);
+            return new IntPtr(SetWindowLong32(hwnd, GWL_EXSTYLE, cur | (int)addFlags));
+        }
+    }
+
+    #endregion
+}
+#endif

--- a/Controller/Classes/OverlayWindowMonoGame.cs
+++ b/Controller/Classes/OverlayWindowMonoGame.cs
@@ -2,35 +2,65 @@
 using System.Windows.Forms;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
+using ButtonState = Microsoft.Xna.Framework.Input.ButtonState;
+using SpriteBatch = Microsoft.Xna.Framework.Graphics.SpriteBatch;
+using Texture2D = Microsoft.Xna.Framework.Graphics.Texture2D;
 
 namespace Blizzard_Controller;
 public class OverlayWindowMonoGame : Game
 {
-    private GraphicsDeviceManager _graphics;
-    private SpriteBatch _spriteBatch;
+    GraphicsDeviceManager graphics;
+    SpriteBatch spriteBatch;
+
+    // Processes
+    Process SC2Proc, SC1Proc, WC3Proc, WC1Proc, WC2Proc;
+
+    // Overlay settings (populated from your GameSettings in the original)
+    int _overlayWidth = 0;
+    int _overlayHeight = 0;
+    int _cellColumns = 0;
+    int _sideOffset = 0;
+    int _bottomOffset = 0;
+
+    // runtime sizes
+    int overlayWidth = 0;
+    int overlayHeight = 0;
+    int cellWidth = 0;
+    int cellHeight = 0;
+
+    // textures
+    Texture2D aBtnImg, xBtnImg, yBtnImg, bBtnImg, backBtnImg;
+    Texture2D lBtnImg, ltBtnImg, rBtnImg;
+    Texture2D ps_xBtn, ps_squareBtn, ps_triangleBtn, ps_circleBtn, ps_shareBtn, ps_l1Btn, ps_l2Btn, ps_r1Btn;
+
+    // helper 1x1 pixel for rectangle lines
+    Texture2D pixel;
+
+    // overlay mode
+    string overlayBtns = "xbox";
+
+    // Win32 handle
+    IntPtr hWnd;
 
     public OverlayWindowMonoGame()
     {
-        _graphics = new GraphicsDeviceManager(this);
-        IsMouseVisible = false; // no cursor
-    }
+        graphics = new GraphicsDeviceManager(this)
+        {
+            PreferMultiSampling = false,
+            SynchronizeWithVerticalRetrace = true
+        };
+        IsMouseVisible = false;
 
-    protected override void LoadContent()
-    {
-        _spriteBatch = new SpriteBatch(GraphicsDevice);
+        // create tiny window first; we'll resize/position later
+        graphics.PreferredBackBufferWidth = 1;
+        graphics.PreferredBackBufferHeight = 1;
+        Window.ClientSizeChanged += (s, e) => { /* no-op */ };
 
-        var hwnd = Window.Handle;
+        Window.AllowUserResizing = false;
+        Window.IsBorderless = true;
 
-        // make window layered + click-through
-        SetWindowExStyle(hwnd, WS_EX_LAYERED | WS_EX_TRANSPARENT);
-
-        MakeBorderless(hwnd);
-
-        // set magenta as transparent color key
-        SetLayeredWindowAttributes(hwnd, COLOR_KEY, 0, LWA_COLORKEY);
-
-        var form = (Form)Control.FromHandle(Window.Handle);
-        form.TopMost = true; // <-- keeps window always on top
+        Content.RootDirectory = "Content";
     }
 
     private void MakeBorderless(IntPtr hwnd)
@@ -48,46 +78,6 @@ public class OverlayWindowMonoGame : Game
         }
     }
 
-
-    protected override void Update(GameTime gameTime)
-    {
-        base.Update(gameTime);
-    }
-
-    protected override void Draw(GameTime gameTime)
-    {
-        // clear with the colorkey color (magenta)
-        GraphicsDevice.Clear(new Microsoft.Xna.Framework.Color(255, 0, 255));
-
-        _spriteBatch.Begin();
-        //_spriteBatch.Draw(GetDummyTexture(Color.White), new Microsoft.Xna.Framework.Rectangle(100, 100, 200, 200), Microsoft.Xna.Framework.Color.White * 0.7f);
-        _spriteBatch.End();
-
-        base.Draw(gameTime);
-    }
-
-    #region Win32 Interop
-
-    const int GWL_EXSTYLE = -20;
-    const uint WS_EX_LAYERED = 0x00080000;
-    const uint WS_EX_TRANSPARENT = 0x00000020;
-    const uint LWA_COLORKEY = 0x00000001;
-    const uint COLOR_KEY = 0x00FF00FF; // magenta in 0x00BBGGRR
-    const int GWL_STYLE = -16;
-    const uint WS_POPUP = 0x80000000;
-
-
-    [DllImport("user32.dll", EntryPoint = "GetWindowLong")]
-    static extern int GetWindowLong32(IntPtr hWnd, int nIndex);
-    [DllImport("user32.dll", EntryPoint = "SetWindowLong")]
-    static extern int SetWindowLong32(IntPtr hWnd, int nIndex, int dwNewLong);
-    [DllImport("user32.dll", EntryPoint = "GetWindowLongPtr")]
-    static extern IntPtr GetWindowLongPtr64(IntPtr hWnd, int nIndex);
-    [DllImport("user32.dll", EntryPoint = "SetWindowLongPtr")]
-    static extern IntPtr SetWindowLongPtr64(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
-    [DllImport("user32.dll")]
-    static extern bool SetLayeredWindowAttributes(IntPtr hwnd, uint crKey, byte bAlpha, uint dwFlags);
-
     private IntPtr SetWindowExStyle(IntPtr hwnd, uint addFlags)
     {
         if (IntPtr.Size == 8)
@@ -103,6 +93,351 @@ public class OverlayWindowMonoGame : Game
         }
     }
 
-    #endregion
+    protected override void LoadContent()
+    {
+        spriteBatch = new SpriteBatch(GraphicsDevice);
+
+        var hwnd = Window.Handle;
+
+        SetWindowExStyle(hwnd, WS_EX_LAYERED | WS_EX_TRANSPARENT);
+
+        MakeBorderless(hwnd);
+
+        // set magenta as transparent color key
+        SetLayeredWindowAttributes(hwnd, COLOR_KEY, 0, LWA_COLORKEY);
+
+        // Create 1x1 white pixel
+        pixel = new Texture2D(GraphicsDevice, 1, 1);
+        pixel.SetData(new[] { Color.White });
+
+        // Load textures from Resources folder (png)
+        aBtnImg = LoadTexture("Resources/a_btn.png");
+        xBtnImg = LoadTexture("Resources/x_btn.png");
+        yBtnImg = LoadTexture("Resources/y_btn.png");
+        bBtnImg = LoadTexture("Resources/b_btn.png");
+        backBtnImg = LoadTexture("Resources/back_btn.png");
+        lBtnImg = LoadTexture("Resources/lb_btn.png");
+        ltBtnImg = LoadTexture("Resources/lt_btn.png");
+        rBtnImg = LoadTexture("Resources/rb_btn.png");
+
+        ps_xBtn = LoadTexture("Resources/ps_x_btn.png");
+        ps_squareBtn = LoadTexture("Resources/ps_square_btn.png");
+        ps_triangleBtn = LoadTexture("Resources/ps_triangle_btn.png");
+        ps_circleBtn = LoadTexture("Resources/ps_circle_btn.png");
+        ps_shareBtn = LoadTexture("Resources/ps_share_btn.png");
+        ps_l1Btn = LoadTexture("Resources/ps_l1_btn.png");
+        ps_l2Btn = LoadTexture("Resources/ps_l2_btn.png");
+        ps_r1Btn = LoadTexture("Resources/ps_r1_btn.png");
+    }
+
+    protected override void UnloadContent()
+    {
+        pixel?.Dispose();
+        aBtnImg?.Dispose();
+        xBtnImg?.Dispose();
+        yBtnImg?.Dispose();
+        bBtnImg?.Dispose();
+        backBtnImg?.Dispose();
+        lBtnImg?.Dispose();
+        ltBtnImg?.Dispose();
+        rBtnImg?.Dispose();
+        ps_xBtn?.Dispose();
+        ps_squareBtn?.Dispose();
+        ps_triangleBtn?.Dispose();
+        ps_circleBtn?.Dispose();
+        ps_shareBtn?.Dispose();
+        ps_l1Btn?.Dispose();
+        ps_l2Btn?.Dispose();
+        ps_r1Btn?.Dispose();
+        base.UnloadContent();
+    }
+
+    int check = 0;
+    Invoke.RECT gameWindowSize = new Invoke.RECT();
+
+    protected override void Update(GameTime gameTime)
+    {
+        if (GamePad.GetState(PlayerIndex.One).Buttons.Back == ButtonState.Pressed)
+            Exit();
+
+        // Poll every ~100 frames ticks (approx matches original check >= 100)
+        if (check++ >= 100)
+        {
+            // detect game processes (use your GameSettings.* names)
+            SC2Proc = GetProcess(GameSettings.ProcessNames.SC2ProcName);
+            SC1Proc = GetProcess(GameSettings.ProcessNames.SC1ProcName);
+            WC3Proc = GetProcess(GameSettings.ProcessNames.WC3ProcName);
+            WC2Proc = GetProcess(GameSettings.ProcessNames.WC2ProcName);
+            WC1Proc = GetProcess(GameSettings.ProcessNames.WC1ProcName);
+
+            if (SC2Proc != null || SC1Proc != null || WC3Proc != null || WC1Proc != null || WC2Proc != null)
+            {
+                if (SC2Proc != null)
+                {
+                    gameWindowSize = GetWindowSize(SC2Proc);
+                    _overlayWidth = GameSettings.StarCraft2.overlayWidth;
+                    _overlayHeight = GameSettings.StarCraft2.overlayHeight;
+                    _cellColumns = GameSettings.StarCraft2.cellColumns;
+                    _bottomOffset = GameSettings.StarCraft2.bottomOffset;
+                    _sideOffset = GameSettings.StarCraft2.sideOffset;
+                }
+                else if (SC1Proc != null)
+                {
+                    gameWindowSize = GetWindowSize(SC1Proc);
+                    _overlayWidth = GameSettings.StarCraft1.overlayWidth;
+                    _overlayHeight = GameSettings.StarCraft1.overlayHeight;
+                    _cellColumns = GameSettings.StarCraft1.cellColumns;
+                    _bottomOffset = GameSettings.StarCraft1.bottomOffset;
+                    _sideOffset = GameSettings.StarCraft1.sideOffset;
+                }
+                else if (WC3Proc != null)
+                {
+                    gameWindowSize = GetWindowSize(WC3Proc);
+                    _overlayWidth = GameSettings.WarCraft3.overlayWidth;
+                    _overlayHeight = GameSettings.WarCraft3.overlayHeight;
+                    _cellColumns = GameSettings.WarCraft3.cellColumns;
+                    _bottomOffset = GameSettings.WarCraft3.bottomOffset;
+                    _sideOffset = GameSettings.WarCraft3.sideOffset;
+                }
+                else if (WC1Proc != null)
+                {
+                    gameWindowSize = GetWindowSize(WC1Proc);
+                    _overlayWidth = GameSettings.WarCraft1.overlayWidth;
+                    _overlayHeight = GameSettings.WarCraft1.overlayHeight;
+                    _cellColumns = GameSettings.WarCraft1.cellColumns;
+                    _bottomOffset = GameSettings.WarCraft1.bottomOffset;
+                    _sideOffset = GameSettings.WarCraft1.sideOffset;
+                }
+                else if (WC2Proc != null)
+                {
+                    gameWindowSize = GetWindowSize(WC2Proc);
+                    _overlayWidth = GameSettings.WarCraft2.overlayWidth;
+                    _overlayHeight = GameSettings.WarCraft2.overlayHeight;
+                    _cellColumns = GameSettings.WarCraft2.cellColumns;
+                    _bottomOffset = GameSettings.WarCraft2.bottomOffset;
+                    _sideOffset = GameSettings.WarCraft2.sideOffset;
+                }
+
+                var gameWidth = Math.Abs(gameWindowSize.Left - gameWindowSize.Right);
+                var gameHeight = Math.Abs(gameWindowSize.Top - gameWindowSize.Bottom);
+
+                float scaleX = gameWidth / 1280f;
+                float scaleY = gameHeight / 720f;
+
+                overlayWidth = (int)(_overlayWidth * scaleX);
+                overlayHeight = (int)(_overlayHeight * scaleY);
+
+                cellWidth = Math.Max(1, overlayWidth / Math.Max(1, _cellColumns));
+                cellHeight = Math.Max(1, overlayHeight / 4);
+
+                // resize textures by recreating scaled versions: MonoGame can't set width/height on Texture2D directly.
+                // Simpler: draw them scaled during Draw using dest rectangles computed from cellWidth/cellHeight.
+
+                // WC3 special aspect offsets
+                if (WC3Proc != null)
+                {
+                    var test = GetAspectRatio(gameWidth, gameHeight);
+                    if (test == 1.8) _sideOffset = Convert.ToInt32(0.135 * gameWidth);
+                    else if (test == 1.6) _sideOffset = Convert.ToInt32(0.095 * gameWidth);
+                    else if (test == 1.5) _sideOffset = Convert.ToInt32(0.080 * gameWidth);
+                }
+
+                int targetWidth = overlayWidth;
+                int targetHeight = overlayHeight;
+
+                int posX;
+                int posY;
+
+                if (WC1Proc != null || WC2Proc != null) // left side
+                {
+                    posX = gameWindowSize.Left - _sideOffset;
+                    posY = gameWindowSize.Bottom - targetHeight - _bottomOffset;
+                }
+                else // right side
+                {
+                    posX = gameWindowSize.Right - targetWidth - _sideOffset;
+                    posY = gameWindowSize.Bottom - targetHeight - _bottomOffset;
+                }
+
+                // Apply window size & position
+                SetWindowPositionAndSize(posX, posY, targetWidth, targetHeight);
+            }
+
+            check = 0;
+        }
+
+        // Handle controller input processes each update
+        ControllerInputs.processButtons();
+        ControllerInputs.processJoysticks();
+
+        base.Update(gameTime);
+    }
+
+    protected override void Draw(GameTime gameTime)
+    {
+        GraphicsDevice.Clear(new Microsoft.Xna.Framework.Color(0,0,0));
+
+        // If no game found, skip drawing
+        if ((SC2Proc == null && SC1Proc == null && WC3Proc == null && WC1Proc == null && WC2Proc == null) ||
+             Math.Abs(gameWindowSize.Left - gameWindowSize.Right) == 0)
+        {
+            base.Draw(gameTime);
+            return;
+        }
+
+        bool leftSide = WC1Proc != null || WC2Proc != null;
+        var pad = GamePad.GetState(PlayerIndex.One);
+        bool anyTrigger = pad.Triggers.Left > 0.5f || pad.Triggers.Right > 0.5f || pad.IsButtonDown(Buttons.LeftTrigger);
+
+        if (anyTrigger)
+        {
+            // draw semi-transparent button images when trigger down
+            float alpha = 0.6f;
+            Microsoft.Xna.Framework.Color tint = Microsoft.Xna.Framework.Color.White * alpha;
+
+            spriteBatch.Begin(samplerState: SamplerState.PointClamp, blendState: BlendState.AlphaBlend);
+
+            // Top row
+            var btnList = new Texture2D[] { aBtnImg, xBtnImg, yBtnImg, bBtnImg, backBtnImg };
+            var psList = new Texture2D[] { ps_xBtn, ps_squareBtn, ps_triangleBtn, ps_circleBtn, ps_shareBtn };
+
+            int c = _cellColumns - (leftSide ? 0 : 1);
+            for (int i = 0; i < _cellColumns - 1; i++)
+            {
+                int dstX = overlayWidth - cellWidth * c--;
+                int dstY = 0;
+                var srcTex = overlayBtns.Equals("Playstation") ? psList[i] : btnList[i];
+                if (srcTex != null)
+                    spriteBatch.Draw(srcTex, new Microsoft.Xna.Framework.Rectangle(dstX, dstY, cellWidth, cellHeight), tint);
+            }
+
+            // side buttons
+            Texture2D rTex = overlayBtns.Equals("Playstation") ? ps_r1Btn : rBtnImg;
+            Texture2D lTex = overlayBtns.Equals("Playstation") ? ps_l1Btn : lBtnImg;
+            Texture2D ltTex = overlayBtns.Equals("Playstation") ? ps_l2Btn : ltBtnImg;
+
+            int sideX = leftSide ? gameWindowSize.Left + cellWidth * (_cellColumns - 1) : 0;
+
+            if (rTex != null)
+                spriteBatch.Draw(rTex, new Microsoft.Xna.Framework.Rectangle(sideX, overlayHeight - (cellHeight * 3), cellWidth, cellHeight), tint);
+            if (lTex != null)
+                spriteBatch.Draw(lTex, new Microsoft.Xna.Framework.Rectangle(sideX, overlayHeight - (cellHeight * 2), cellWidth, cellHeight), tint);
+            if (WC1Proc == null && ltTex != null)
+                spriteBatch.Draw(ltTex, new Microsoft.Xna.Framework.Rectangle(sideX, overlayHeight - cellHeight, cellWidth, cellHeight), tint);
+
+            // row highlighting (green outlines) for triggers
+            if (pad.Triggers.Right > 0.5f)
+                DrawRectangleLines(spriteBatch, new Microsoft.Xna.Framework.Rectangle(cellWidth, overlayHeight - cellHeight * 3 - 1, overlayWidth - cellWidth, cellHeight), 2, Microsoft.Xna.Framework.Color.Green);
+            if (pad.Triggers.Left > 0.5f)
+                DrawRectangleLines(spriteBatch, new Microsoft.Xna.Framework.Rectangle(cellWidth, overlayHeight - cellHeight * 2 - 1, overlayWidth - cellWidth, cellHeight), 2, Microsoft.Xna.Framework.Color.Green);
+            if (pad.IsButtonDown(Buttons.LeftShoulder) && WC1Proc == null) // approximate LeftTrigger2
+                DrawRectangleLines(spriteBatch, new Microsoft.Xna.Framework.Rectangle(cellWidth, overlayHeight - cellHeight - 1, overlayWidth - cellWidth, cellHeight), 2, Microsoft.Xna.Framework.Color.Green);
+
+            spriteBatch.End();
+        }
+
+        base.Draw(gameTime);
+    }
+
+    // --- helpers ---
+
+    Texture2D LoadTexture(string path)
+    {
+        if (!File.Exists(path)) return null;
+        using var fs = File.OpenRead(path);
+        return Texture2D.FromStream(GraphicsDevice, fs);
+    }
+
+    void DrawRectangleLines(SpriteBatch sb, Microsoft.Xna.Framework.Rectangle rect, int thickness, Microsoft.Xna.Framework.Color color)
+    {
+        // top
+        sb.Draw(pixel, new Microsoft.Xna.Framework.Rectangle(rect.Left, rect.Top, rect.Width, thickness), color);
+        // bottom
+        sb.Draw(pixel, new Microsoft.Xna.Framework.Rectangle(rect.Left, rect.Bottom - thickness, rect.Width, thickness), color);
+        // left
+        sb.Draw(pixel, new Microsoft.Xna.Framework.Rectangle(rect.Left, rect.Top, thickness, rect.Height), color);
+        // right
+        sb.Draw(pixel, new Microsoft.Xna.Framework.Rectangle(rect.Right - thickness, rect.Top, thickness, rect.Height), color);
+    }
+
+    double GetAspectRatio(int width, int height)
+    {
+        var roundThis = (double)width / height;
+        return Math.Round(roundThis, 1);
+    }
+
+    public static Process GetProcess(string procName)
+    {
+        return Process.GetProcessesByName(procName).FirstOrDefault();
+    }
+
+    // Uses your existing Invoke.GetWindowRect
+    public Invoke.RECT GetWindowSize(Process gameProc)
+    {
+        Invoke.RECT gameWindowSize = new Invoke.RECT();
+        Invoke.GetWindowRect(gameProc.MainWindowHandle, out gameWindowSize);
+        return gameWindowSize;
+    }
+
+    // Window positioning/resizing helpers (Win32)
+    void SetWindowPositionAndSize(int x, int y, int width, int height)
+    {
+        if (hWnd == IntPtr.Zero) hWnd = WindowHandle();
+        if (hWnd == IntPtr.Zero) return;
+
+        // set client size via MoveWindow
+        MoveWindow(hWnd, x, y, width, height, true);
+
+        SetWindowPos(hWnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+    }
+
+    // Try to obtain Window handle by calling GetActiveWindow as fallback
+    IntPtr WindowHandle()
+    {
+        return GetActiveWindow();
+    }
+
+    // --- Win32 interop constants & functions ---
+    const int GWL_EXSTYLE = -20;
+    const int WS_EX_LAYERED = 0x00080000;
+    const int WS_EX_TRANSPARENT = 0x00000020;
+    const int WS_EX_TOPMOST = 0x00000008;
+    const int LWA_ALPHA = 0x02;
+    static readonly IntPtr HWND_TOPMOST = new IntPtr(-1);
+    const uint SWP_NOMOVE = 0x0002;
+    const uint SWP_NOSIZE = 0x0001;
+    const uint SWP_SHOWWINDOW = 0x0040;
+    public const int LWA_COLORKEY = 0x1;
+    const int GWL_STYLE = -16;
+    const uint WS_POPUP = 0x80000000;
+    const uint COLOR_KEY = 0x00000000; // magenta in 0x00BBGGRR
+
+    [DllImport("user32.dll")]
+    static extern IntPtr GetActiveWindow();
+
+    [DllImport("user32.dll", SetLastError = true)]
+    static extern int GetWindowLong(IntPtr hWnd, int nIndex);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    static extern int SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
+    [DllImport("user32.dll", EntryPoint = "GetWindowLong")]
+    static extern int GetWindowLong32(IntPtr hWnd, int nIndex);
+    [DllImport("user32.dll", EntryPoint = "SetWindowLong")]
+    static extern int SetWindowLong32(IntPtr hWnd, int nIndex, int dwNewLong);
+    [DllImport("user32.dll", EntryPoint = "GetWindowLongPtr")]
+    static extern IntPtr GetWindowLongPtr64(IntPtr hWnd, int nIndex);
+    [DllImport("user32.dll", EntryPoint = "SetWindowLongPtr")]
+    static extern IntPtr SetWindowLongPtr64(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    static extern bool SetLayeredWindowAttributes(IntPtr hwnd, uint crKey, byte bAlpha, uint dwFlags);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    static extern bool MoveWindow(IntPtr hWnd, int X, int Y, int nWidth, int nHeight, bool bRepaint);
+
+    // end Win32
 }
 #endif

--- a/Controller/Controller.csproj
+++ b/Controller/Controller.csproj
@@ -1,48 +1,38 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <!-- Target plain net8.0 (cross‑platform) -->
-    <TargetFramework>net8.0</TargetFramework>
-    <OutputType>Exe</OutputType>
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<OutputType>Exe</OutputType>
+		<RootNamespace>Controller</RootNamespace>
+		<AssemblyName>Controller</AssemblyName>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<BaseOutputPath>../bin</BaseOutputPath>
+	</PropertyGroup>
 
-    <!-- Keep name consistent -->
-    <RootNamespace>Controller</RootNamespace>
-    <AssemblyName>Controller</AssemblyName>
+	<PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+		<TargetFramework>net8.0-windows</TargetFramework>
+		<DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
+		<UseWindowsForms>true</UseWindowsForms>
+	</PropertyGroup>
 
-    <!-- Remove Windows‑only settings -->
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <UseWindowsForms>false</UseWindowsForms>
-    <BaseOutputPath>../bin</BaseOutputPath>
+	<PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
+		<DefineConstants>$(DefineConstants);MACOS</DefineConstants>
+	</PropertyGroup>
 
-    <!-- Remove Windows‑only manifest and platform target -->
-    <!--<ApplicationManifest>app.manifest</ApplicationManifest>-->
-    <!--<PlatformTarget>x86</PlatformTarget>-->
-  </PropertyGroup>
+	<PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
+		<DefineConstants>$(DefineConstants);LINUX</DefineConstants>
+	</PropertyGroup>
 
-  <!-- Remove .nuget clean section (not needed cross‑platform) -->
+	<ItemGroup>
+		<PackageReference Include="MonoGame.Framework.WindowsDX" Version="3.8.4" />
+		<PackageReference Include="Raylib-cs" Version="7.0.1" />
+		<PackageReference Include="SharpHook" Version="6.2.0" />
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.7" />
+		<PackageReference Include="System.Resources.Extensions" Version="9.0.7" />
+	</ItemGroup>
 
-<PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
-  <DefineConstants>$(DefineConstants);MACOS</DefineConstants>
-</PropertyGroup>
-
-<PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
-  <DefineConstants>$(DefineConstants);LINUX</DefineConstants>
-</PropertyGroup>
-
-<PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-  <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
-</PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Raylib-cs" Version="7.0.1" />
-    <PackageReference Include="SharpHook" Version="6.2.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.7" />
-    <PackageReference Include="System.Resources.Extensions" Version="9.0.7" />
-  </ItemGroup>
-
-  <!-- Keep resources -->
-  <ItemGroup>
-  <Content Include="Resources\**\*.*">
-    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-  </Content>
-</ItemGroup>
+	<ItemGroup>
+		<Content Include="Resources\**\*.*">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</Content>
+	</ItemGroup>
 </Project>

--- a/Controller/Controller.csproj
+++ b/Controller/Controller.csproj
@@ -11,7 +11,6 @@
 	<PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
 		<TargetFramework>net8.0-windows</TargetFramework>
 		<DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
-		<UseWindowsForms>true</UseWindowsForms>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">

--- a/Controller/Controller.csproj
+++ b/Controller/Controller.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
-		<OutputType>Exe</OutputType>
+		<OutputType>WinExe</OutputType>
 		<RootNamespace>Controller</RootNamespace>
 		<AssemblyName>Controller</AssemblyName>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/Controller/Program.cs
+++ b/Controller/Program.cs
@@ -1,10 +1,17 @@
-﻿namespace Blizzard_Controller;
+﻿using SharpDX.XInput;
+
+namespace Blizzard_Controller;
 
 static class Program
 {
     static void Main()
     {
+#if WINDOWS
+        var game = new OverlayWindowMonoGame();
+        game.Run();
+#else
         var form = new OverlayWindow();
         form.Initialize();
+#endif
     }
 }

--- a/Controller/Program.cs
+++ b/Controller/Program.cs
@@ -1,6 +1,4 @@
-﻿using SharpDX.XInput;
-
-namespace Blizzard_Controller;
+﻿namespace Blizzard_Controller;
 
 static class Program
 {

--- a/Controller_v2.Desktop/Controller_v2.Desktop.csproj
+++ b/Controller_v2.Desktop/Controller_v2.Desktop.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <OutputType>WinExe</OutputType>
     <!--If you are willing to use Windows/MacOS native APIs you will need to create 3 projects.
     One for Windows with net8.0-windows TFM, one for MacOS with net8.0-macos and one with net8.0 TFM for Linux.-->
     <TargetFramework>net8.0</TargetFramework>

--- a/Controller_v2.Desktop/Controller_v2.Desktop.csproj
+++ b/Controller_v2.Desktop/Controller_v2.Desktop.csproj
@@ -19,7 +19,9 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-    <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
+	  <TargetFramework>net8.0-windows</TargetFramework>
+	  <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
+	  <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Controller_v2.Desktop/Controller_v2.Desktop.csproj
+++ b/Controller_v2.Desktop/Controller_v2.Desktop.csproj
@@ -21,7 +21,6 @@
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
 	  <TargetFramework>net8.0-windows</TargetFramework>
 	  <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
-	  <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Controller_v2.Desktop/app.manifest
+++ b/Controller_v2.Desktop/app.manifest
@@ -3,7 +3,7 @@
   <!-- This manifest is used on Windows only.
        Don't remove it as it might cause problems with window transparency and embeded controls.
        For more details visit https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests -->
-  <assemblyIdentity version="3.0.0.0" name="AvaloniaTest.Desktop"/>
+  <assemblyIdentity version="3.1.0.0" name="AvaloniaTest.Desktop"/>
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>

--- a/Controller_v2/App.axaml.cs
+++ b/Controller_v2/App.axaml.cs
@@ -52,8 +52,13 @@ public partial class App : Application
 #else // macos, windows
                 Avalonia.Threading.Dispatcher.UIThread.Post(() =>
                 {
-                    var ow = new OverlayWindow();
-                    ow.Initialize();
+#if WINDOWS
+                    var game = new OverlayWindowMonoGame();
+                    game.Run();
+#else
+                    var form = new OverlayWindow();
+                    form.Initialize();
+#endif
                 });
 #endif
             }

--- a/Controller_v2/App.axaml.cs
+++ b/Controller_v2/App.axaml.cs
@@ -48,17 +48,18 @@ public partial class App : Application
                     OverlayWindow ow = new OverlayWindow();
                     ow.Initialize();
                 });
-
-#else // macos, windows
-                Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+#elif WINDOWS
+                Task.Run(() =>
                 {
-#if WINDOWS
                     var game = new OverlayWindowMonoGame();
                     game.Run();
-#else
+                });
+
+#else // macos
+                Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+                {
                     var form = new OverlayWindow();
                     form.Initialize();
-#endif
                 });
 #endif
             }

--- a/Controller_v2/Controller_v2.csproj
+++ b/Controller_v2/Controller_v2.csproj
@@ -18,7 +18,9 @@
 </PropertyGroup>
 
 <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-  <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
+	<TargetFramework>net8.0-windows</TargetFramework>
+	<DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
+	<UseWindowsForms>true</UseWindowsForms>
 </PropertyGroup>
 
   <ItemGroup>

--- a/Controller_v2/Controller_v2.csproj
+++ b/Controller_v2/Controller_v2.csproj
@@ -20,7 +20,6 @@
 <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
 	<TargetFramework>net8.0-windows</TargetFramework>
 	<DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
-	<UseWindowsForms>true</UseWindowsForms>
 </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I have to use DirectX to get transparency working when remote gaming using something like Steam, Moonlight, etc.

We will use Monogame's WindowsDX library to create a DirectX window that is transparent, click-through, no topbar and top-most.

Integration was difficult due to Monogame requiring net8.0-windows as the framework and I want this project to be cross platform. I had to use PropertyGroup Conditions to check if the OS is Windows and to apply that framework instead.

Currently this is not complete.

**What's done:**
- Tested monogame windowsDX with Moonlight, transparency works!
- Integrated Monogame into the Controller project.
- Monogame window is transparent, click-through, no topbar and top-most.
- Tested running/compiling on Windows, appears to be stable. 
- Placeed buttons and functionality into the overlay
- Tested cross-platform compiling on macos and windows